### PR TITLE
add substructure variables to jet output in pythia analysis

### DIFF
--- a/generators/pythia/main_PhPy8_HZA_dohist.cc
+++ b/generators/pythia/main_PhPy8_HZA_dohist.cc
@@ -15,8 +15,8 @@
 using namespace Pythia8;
 using namespace std;
 
-constexpr double pi     = 3.14159265358979323846;
-constexpr double twoPi  = 2.0 * pi;
+constexpr double pi     = M_PI;
+constexpr double twoPi  = 2.0 * M_PI;
 
 /// Pretty printing of Pythia particle
 std::ostream& operator<<(std::ostream& os, const Pythia8::Particle & p) {

--- a/generators/pythia/main_PhPy8_HZA_dohist.cc
+++ b/generators/pythia/main_PhPy8_HZA_dohist.cc
@@ -15,6 +15,9 @@
 using namespace Pythia8;
 using namespace std;
 
+constexpr double pi     = 3.14159265358979323846;
+constexpr double twoPi  = 2.0 * pi;
+
 /// Pretty printing of Pythia particle
 std::ostream& operator<<(std::ostream& os, const Pythia8::Particle & p) {
   os << "["
@@ -81,6 +84,14 @@ void printHist(const string & fname, const Pythia8::Hist & hh)
   hh.pyplotTable(outfile, true, false);
   outfile.close();
 }
+
+/// Helper struct for track information
+struct TrackSummary {
+  double pt;
+  double eta;
+  double phi;
+  double deltaR;
+};
 
 
 int main(int argc, char* argv[]) {
@@ -226,6 +237,14 @@ int main(int argc, char* argv[]) {
   Hist h_gtproxy_U1("hist_proxy_U1_0p7", 40, 0.0, 0.4);
   Hist h_gtproxy_M2("hist_proxy_M2_0p3", 40, 0.0, 0.4);
   Hist h_gtproxy_tau2("hist_proxy_tau2", 40, 0.0, 1.0);
+
+  // Helper function for delta phi calculation (used in loop)
+    auto deltaPhi = [](double phi1, double phi2) {
+      double dphi = phi1 - phi2;
+      while (dphi > pi)  dphi -= twoPi;
+      while (dphi < -pi) dphi += twoPi;
+      return dphi;
+    };
 
   for (int iEvent = 0; iEvent < nEvents; ++iEvent) {
 
@@ -499,22 +518,7 @@ int main(int argc, char* argv[]) {
     const double jetEta = slowJet.p(finjet).eta(); 
     const double jetPhi = slowJet.phi(finjet);
     const double jetR   = 0.4;
-    const double pi     = std::acos(-1.0);
-    const double twoPi  = 2.0 * pi;
 
-    auto deltaPhi = [pi, twoPi](double phi1, double phi2) {
-      double dphi = phi1 - phi2;
-      while (dphi > pi)  dphi -= twoPi;
-      while (dphi < -pi) dphi += twoPi;
-      return dphi;
-    };
-
-    struct TrackSummary {
-      double pt;
-      double eta;
-      double phi;
-      double deltaR;
-    };
     std::vector<TrackSummary> jetTracks;
     double sumTrackPt = 0.0;
 

--- a/generators/pythia/plot_PhPy8_HZA_dohist.py
+++ b/generators/pythia/plot_PhPy8_HZA_dohist.py
@@ -10,7 +10,14 @@ hists = [
     "hist_lem_pt",
     "hist_lep_pt",
     "hist_mlljet",
-    "hist_z_mass"
+    "hist_z_mass",
+    "hist_proxy_nTracks",
+    "hist_proxy_deltaRLeadTrack",
+    "hist_proxy_leadTrackPtRatio",
+    "hist_proxy_angularity_2",
+    "hist_proxy_U1_0p7",
+    "hist_proxy_M2_0p3",
+    "hist_proxy_tau2"
 ]
 
 OPT = "_reallep_MPIon_ISRon_FSRon_HADon"

--- a/setup_powheg.sh
+++ b/setup_powheg.sh
@@ -76,3 +76,4 @@ popd
 # install PDF sets with LHAPDF
 lhapdf install NNPDF30_nlo_as_0118
 lhapdf install MSTW2008nlo68cl
+lhapdf install NNPDF23_lo_as_0130_qed


### PR DESCRIPTION
Add substructure variables to jet output in Pythia plotting which were used as input features to the neural networks in the ATLAS publication.